### PR TITLE
Remove invalid KV configuration

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,7 +7,7 @@ compatibility_date = "2024-05-01"
 # GOOGLE_CLIENT_SECRET = ""
 # allowed to define environment variables externally
 
-[kv_namespaces]
 # Example KV binding for token storage
+# [[kv_namespaces]]
 # binding = "TOKENS"
 # id = "00000000000000000000000000000000000"


### PR DESCRIPTION
## Summary
- remove misconfigured `kv_namespaces` table
- document KV example as comments in `wrangler.toml`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acf7ad656883259898bea6fcbacd2f