### PR TITLE
feat: add in-browser tools for verification and indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is deliberately minimal and friendly. Each step returns human‑readable summ
 
 ## Using
 
-Visit the worker URL. The page invites you to connect a Google account. After OAuth completes the API endpoints become available:
+Visit the worker URL. The page invites you to connect a Google account. After OAuth completes, simple controls appear to fetch a DNS verification token, confirm verification, request URL indexing and submit a sitemap. The same operations are also available via JSON endpoints:
 
 - `POST /api/verify` to receive a verification token.
 - `POST /api/confirm` once the token is placed.

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -30,10 +30,77 @@ button { padding: 0.5rem 1rem; }
         app.append(btn);
         return;
       }
-      // placeholder for further steps
-      const p = document.createElement('p');
-      p.textContent = 'Account connected. Continue in your client app via API calls.';
-      app.append(p);
+      // domain input shared by multiple steps
+      const domainStep = document.createElement('div');
+      domainStep.className = 'step';
+      const domainTitle = document.createElement('h2');
+      domainTitle.textContent = 'Verify domain';
+      const domainInput = document.createElement('input');
+      domainInput.placeholder = 'example.com';
+      domainStep.append(domainTitle, domainInput);
+
+      // verification: get DNS token
+      const tokenBtn = document.createElement('button');
+      tokenBtn.textContent = 'Get DNS token';
+      const tokenOut = document.createElement('pre');
+      tokenBtn.onclick = async () => {
+        const site = domainInput.value.trim();
+        if(!site) return alert('Enter domain');
+        const res = await api('/api/verify',{method:'POST',body:JSON.stringify({site,type:'INET_DOMAIN'})});
+        tokenOut.textContent = res.success ? res.details.token : res.summary;
+      };
+      domainStep.append(tokenBtn, tokenOut);
+
+      // verification confirmation
+      const confirmBtn = document.createElement('button');
+      confirmBtn.textContent = 'Confirm verification';
+      confirmBtn.onclick = async () => {
+        const site = domainInput.value.trim();
+        if(!site) return alert('Enter domain');
+        const res = await api('/api/confirm',{method:'POST',body:JSON.stringify({site,type:'INET_DOMAIN'})});
+        alert(res.summary);
+      };
+      domainStep.append(confirmBtn);
+      app.append(domainStep);
+
+      // indexing step
+      const indexStep = document.createElement('div');
+      indexStep.className = 'step';
+      const indexTitle = document.createElement('h2');
+      indexTitle.textContent = 'Index URL';
+      const urlInput = document.createElement('input');
+      urlInput.placeholder = 'https://example.com/';
+      const indexBtn = document.createElement('button');
+      indexBtn.textContent = 'Index URL';
+      indexBtn.onclick = async () => {
+        const url = urlInput.value.trim();
+        if(!url) return alert('Enter URL');
+        const res = await api('/api/reindex',{method:'POST',body:JSON.stringify({url,eligible:true})});
+        alert(res.summary);
+      };
+      indexStep.append(indexTitle, urlInput, indexBtn);
+      app.append(indexStep);
+
+      // sitemap submission step
+      const sitemapStep = document.createElement('div');
+      sitemapStep.className = 'step';
+      const sitemapTitle = document.createElement('h2');
+      sitemapTitle.textContent = 'Submit sitemap';
+      const sitemapInput = document.createElement('input');
+      sitemapInput.placeholder = 'https://example.com/sitemap.xml';
+      const sitemapBtn = document.createElement('button');
+      sitemapBtn.textContent = 'Submit sitemap';
+      sitemapBtn.onclick = async () => {
+        const domain = domainInput.value.trim();
+        const sitemap = sitemapInput.value.trim();
+        if(!domain || !sitemap) return alert('Enter domain and sitemap');
+        const site = 'sc-domain:' + domain;
+        await api('/api/property',{method:'POST',body:JSON.stringify({site})});
+        const res = await api('/api/sitemap',{method:'POST',body:JSON.stringify({site,sitemap})});
+        alert(res.summary);
+      };
+      sitemapStep.append(sitemapTitle, sitemapInput, sitemapBtn);
+      app.append(sitemapStep);
     }
     api('/api/state').then(r=>{state=r.details||{}; render();});
   </script>


### PR DESCRIPTION
## Summary
- add verification, indexing, and sitemap submission controls to the worker UI
- describe new UI capabilities in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad2d2b977883258fb58c30c46785e9