### PR TITLE
Refactor UI to call Google services directly

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,100 +1,10 @@
-import { ApiResponse, Env } from './types';
 import { renderUI } from './ui';
-import { authUrl, exchangeCode, getVerificationToken, verifySite, addProperty, submitSitemap, inspectUrl, requestIndexing } from './google';
-import { TokenStore } from './storage';
+import { Env } from './types';
 
-function json<T>(data: ApiResponse<T>, status = 200): Response {
-  return new Response(JSON.stringify(data), { status, headers: { 'content-type': 'application/json' } });
-}
-
-export async function handleRequest(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+export async function handleRequest(request: Request, _env: Env, _ctx: ExecutionContext): Promise<Response> {
   const url = new URL(request.url);
-  const store = new TokenStore(env);
-
   if (url.pathname === '/' && request.method === 'GET') {
     return renderUI();
   }
-
-  if (url.pathname === '/api/state') {
-    const token = await store.get('user');
-    return json({ success: true, summary: 'current state', details: { authed: !!token } });
-  }
-
-  if (url.pathname === '/api/oauth/start') {
-    const state = crypto.randomUUID();
-    // state should be stored to validate callback; omitted for brevity
-    const redirect = new URL('/api/oauth/callback', url.origin).toString();
-    const target = authUrl(env, state, redirect);
-    return Response.redirect(target, 302);
-  }
-
-  if (url.pathname === '/api/oauth/callback') {
-    const code = url.searchParams.get('code');
-    const redirect = new URL('/api/oauth/callback', url.origin).toString();
-    if (!code) return json({ success: false, summary: 'Missing code' }, 400);
-    try {
-      const tokens = (await exchangeCode(env, code, redirect)) as { access_token: string; refresh_token: string; expires_in: number };
-      await store.put('user', {
-        access_token: tokens.access_token,
-        refresh_token: tokens.refresh_token,
-        expiry: Date.now() + tokens.expires_in * 1000
-      });
-      return Response.redirect('/', 302);
-    } catch (err) {
-      return json({ success: false, summary: 'OAuth exchange failed' }, 500);
-    }
-  }
-
-  if (url.pathname === '/api/verify' && request.method === 'POST') {
-    const token = await store.get('user');
-    if (!token) return json({ success: false, summary: 'Not authenticated' }, 401);
-    const { site, type } = (await request.json()) as { site: string; type: 'INET_DOMAIN' | 'URL' };
-    const res = await getVerificationToken(token.access_token, site, type);
-    return json(res);
-  }
-
-  if (url.pathname === '/api/confirm' && request.method === 'POST') {
-    const token = await store.get('user');
-    if (!token) return json({ success: false, summary: 'Not authenticated' }, 401);
-    const { site, type } = (await request.json()) as { site: string; type: 'INET_DOMAIN' | 'URL' };
-    const res = await verifySite(token.access_token, site, type);
-    return json(res);
-  }
-
-  if (url.pathname === '/api/property' && request.method === 'POST') {
-    const token = await store.get('user');
-    if (!token) return json({ success: false, summary: 'Not authenticated' }, 401);
-    const { site } = (await request.json()) as { site: string };
-    const res = await addProperty(token.access_token, site);
-    return json(res);
-  }
-
-  if (url.pathname === '/api/sitemap' && request.method === 'POST') {
-    const token = await store.get('user');
-    if (!token) return json({ success: false, summary: 'Not authenticated' }, 401);
-    const { site, sitemap } = (await request.json()) as { site: string; sitemap: string };
-    const res = await submitSitemap(token.access_token, site, sitemap);
-    return json(res);
-  }
-
-  if (url.pathname === '/api/url' && request.method === 'POST') {
-    const token = await store.get('user');
-    if (!token) return json({ success: false, summary: 'Not authenticated' }, 401);
-    const { site, url: target } = (await request.json()) as { site: string; url: string };
-    const res = await inspectUrl(token.access_token, site, target);
-    return json(res);
-  }
-
-  if (url.pathname === '/api/reindex' && request.method === 'POST') {
-    const token = await store.get('user');
-    if (!token) return json({ success: false, summary: 'Not authenticated' }, 401);
-    const { url: target, eligible } = (await request.json()) as { url: string; eligible: boolean };
-    if (!eligible) {
-      return json({ success: false, summary: 'This content is not eligible for instant indexing. Keep sitemaps fresh and use internal links.' }, 400);
-    }
-    const res = await requestIndexing(token.access_token, target);
-    return json(res);
-  }
-
-  return json({ success: false, summary: 'Not found' }, 404);
+  return new Response('Not found', { status: 404 });
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -8,29 +8,79 @@ export function renderUI(): Response {
 body { font-family: sans-serif; margin: 2rem; max-width: 40rem; }
 button { padding: 0.5rem 1rem; }
 .step { margin-bottom: 1.5rem; }
+input { margin-right: 0.5rem; }
 </style>
 </head>
 <body>
   <h1>Welcome</h1>
-  <p>This helper walks you through connecting your site to Google Search Console.</p>
+  <p>This helper walks you through connecting your site to Google Search Console without a separate API layer.</p>
   <div id="app"></div>
   <script type="module">
-    async function api(path, opts){
-      const res = await fetch(path, Object.assign({headers:{'Content-Type':'application/json'}}, opts));
+    const CLIENT_ID = 'YOUR_CLIENT_ID';
+    const CLIENT_SECRET = 'YOUR_CLIENT_SECRET';
+    const REDIRECT_URI = window.location.origin + '/';
+
+    async function exchange(code) {
+      const body = new URLSearchParams({
+        code,
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        redirect_uri: REDIRECT_URI,
+        grant_type: 'authorization_code'
+      });
+      const res = await fetch('https://oauth2.googleapis.com/token', { method: 'POST', body });
+      if (!res.ok) throw new Error('token exchange failed');
       return res.json();
     }
+
+    let tokens = JSON.parse(localStorage.getItem('tokens') || 'null');
+    const params = new URLSearchParams(window.location.search);
+    if (!tokens && params.get('code')) {
+      try {
+        tokens = await exchange(params.get('code'));
+        localStorage.setItem('tokens', JSON.stringify(tokens));
+        window.history.replaceState({}, '', '/');
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    function authed() {
+      return tokens && tokens.access_token;
+    }
+
+    async function api(url, opts) {
+      opts = opts || {};
+      opts.headers = Object.assign({
+        'Authorization': 'Bearer ' + tokens.access_token,
+        'Content-Type': 'application/json'
+      }, opts.headers || {});
+      const res = await fetch(url, opts);
+      return res.json();
+    }
+
     const app = document.getElementById('app');
-    let state = {};
-    function render(){
+
+    function render() {
       app.innerHTML = '';
-      if(!state.authed){
+      if (!authed()) {
         const btn = document.createElement('button');
         btn.textContent = 'Connect Google account';
-        btn.onclick = () => window.location.href = '/api/oauth/start';
+        btn.onclick = () => {
+          const p = new URLSearchParams({
+            client_id: CLIENT_ID,
+            redirect_uri: REDIRECT_URI,
+            response_type: 'code',
+            scope: 'https://www.googleapis.com/auth/webmasters https://www.googleapis.com/auth/indexing https://www.googleapis.com/auth/siteverification',
+            access_type: 'offline',
+            prompt: 'consent'
+          });
+          window.location.href = 'https://accounts.google.com/o/oauth2/v2/auth?' + p.toString();
+        };
         app.append(btn);
         return;
       }
-      // domain input shared by multiple steps
+
       const domainStep = document.createElement('div');
       domainStep.className = 'step';
       const domainTitle = document.createElement('h2');
@@ -39,31 +89,34 @@ button { padding: 0.5rem 1rem; }
       domainInput.placeholder = 'example.com';
       domainStep.append(domainTitle, domainInput);
 
-      // verification: get DNS token
       const tokenBtn = document.createElement('button');
       tokenBtn.textContent = 'Get DNS token';
       const tokenOut = document.createElement('pre');
       tokenBtn.onclick = async () => {
         const site = domainInput.value.trim();
-        if(!site) return alert('Enter domain');
-        const res = await api('/api/verify',{method:'POST',body:JSON.stringify({site,type:'INET_DOMAIN'})});
-        tokenOut.textContent = res.success ? res.details.token : res.summary;
+        if (!site) return alert('Enter domain');
+        const res = await api('https://www.googleapis.com/siteVerification/v1/token', {
+          method: 'POST',
+          body: JSON.stringify({ site: { identifier: site, type: 'INET_DOMAIN' } })
+        });
+        tokenOut.textContent = res.token || (res.error && res.error.message) || 'Failed';
       };
       domainStep.append(tokenBtn, tokenOut);
 
-      // verification confirmation
       const confirmBtn = document.createElement('button');
       confirmBtn.textContent = 'Confirm verification';
       confirmBtn.onclick = async () => {
         const site = domainInput.value.trim();
-        if(!site) return alert('Enter domain');
-        const res = await api('/api/confirm',{method:'POST',body:JSON.stringify({site,type:'INET_DOMAIN'})});
-        alert(res.summary);
+        if (!site) return alert('Enter domain');
+        const res = await api('https://www.googleapis.com/siteVerification/v1/webResource?verificationMethod=DNS_TXT', {
+          method: 'POST',
+          body: JSON.stringify({ site: { identifier: site, type: 'INET_DOMAIN' } })
+        });
+        alert(res.error ? 'Verification failed' : 'Site verified');
       };
       domainStep.append(confirmBtn);
       app.append(domainStep);
 
-      // indexing step
       const indexStep = document.createElement('div');
       indexStep.className = 'step';
       const indexTitle = document.createElement('h2');
@@ -74,14 +127,16 @@ button { padding: 0.5rem 1rem; }
       indexBtn.textContent = 'Index URL';
       indexBtn.onclick = async () => {
         const url = urlInput.value.trim();
-        if(!url) return alert('Enter URL');
-        const res = await api('/api/reindex',{method:'POST',body:JSON.stringify({url,eligible:true})});
-        alert(res.summary);
+        if (!url) return alert('Enter URL');
+        const res = await api('https://indexing.googleapis.com/v3/urlNotifications:publish', {
+          method: 'POST',
+          body: JSON.stringify({ url, type: 'URL_UPDATED' })
+        });
+        alert(res.error ? 'Indexing request failed' : 'Indexing notified');
       };
       indexStep.append(indexTitle, urlInput, indexBtn);
       app.append(indexStep);
 
-      // sitemap submission step
       const sitemapStep = document.createElement('div');
       sitemapStep.className = 'step';
       const sitemapTitle = document.createElement('h2');
@@ -93,16 +148,40 @@ button { padding: 0.5rem 1rem; }
       sitemapBtn.onclick = async () => {
         const domain = domainInput.value.trim();
         const sitemap = sitemapInput.value.trim();
-        if(!domain || !sitemap) return alert('Enter domain and sitemap');
+        if (!domain || !sitemap) return alert('Enter domain and sitemap');
         const site = 'sc-domain:' + domain;
-        await api('/api/property',{method:'POST',body:JSON.stringify({site})});
-        const res = await api('/api/sitemap',{method:'POST',body:JSON.stringify({site,sitemap})});
-        alert(res.summary);
+        await api('https://searchconsole.googleapis.com/v1/sites/' + encodeURIComponent(site), { method: 'PUT' });
+        const res = await api('https://searchconsole.googleapis.com/v1/sites/' + encodeURIComponent(site) + '/sitemaps/' + encodeURIComponent(sitemap), { method: 'PUT' });
+        alert(res.error ? 'Sitemap submission failed' : 'Sitemap submitted');
       };
       sitemapStep.append(sitemapTitle, sitemapInput, sitemapBtn);
       app.append(sitemapStep);
+
+      const inspectStep = document.createElement('div');
+      inspectStep.className = 'step';
+      const inspectTitle = document.createElement('h2');
+      inspectTitle.textContent = 'Inspect URL';
+      const inspectInput = document.createElement('input');
+      inspectInput.placeholder = 'https://example.com/';
+      const inspectBtn = document.createElement('button');
+      inspectBtn.textContent = 'Inspect URL';
+      inspectBtn.onclick = async () => {
+        const domain = domainInput.value.trim();
+        const target = inspectInput.value.trim();
+        if (!domain || !target) return alert('Enter domain and URL');
+        const site = 'sc-domain:' + domain;
+        const res = await api('https://searchconsole.googleapis.com/v1/urlInspection/index:inspect', {
+          method: 'POST',
+          body: JSON.stringify({ inspectionUrl: target, siteUrl: site })
+        });
+        const verdict = res.inspectionResult && res.inspectionResult.indexStatusResult && res.inspectionResult.indexStatusResult.verdict;
+        alert(verdict || (res.error && res.error.message) || 'Done');
+      };
+      inspectStep.append(inspectTitle, inspectInput, inspectBtn);
+      app.append(inspectStep);
     }
-    api('/api/state').then(r=>{state=r.details||{}; render();});
+
+    render();
   </script>
 </body>
 </html>`;


### PR DESCRIPTION
## Summary
- remove worker API endpoints and only serve HTML
- embed OAuth and Google API calls in client-side script

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad306b5fd88325857fce7cdbe95229