### PR TITLE
Use Cloudflare secrets for OAuth client

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,10 +1,10 @@
 import { renderUI } from './ui';
 import { Env } from './types';
 
-export async function handleRequest(request: Request, _env: Env, _ctx: ExecutionContext): Promise<Response> {
+export async function handleRequest(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
   const url = new URL(request.url);
   if (url.pathname === '/' && request.method === 'GET') {
-    return renderUI();
+    return renderUI(env);
   }
   return new Response('Not found', { status: 404 });
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,4 +1,6 @@
-export function renderUI(): Response {
+import { Env } from './types';
+
+export function renderUI(env: Env): Response {
   const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -16,8 +18,8 @@ input { margin-right: 0.5rem; }
   <p>This helper walks you through connecting your site to Google Search Console without a separate API layer.</p>
   <div id="app"></div>
   <script type="module">
-    const CLIENT_ID = 'YOUR_CLIENT_ID';
-    const CLIENT_SECRET = 'YOUR_CLIENT_SECRET';
+    const CLIENT_ID = '${env.GOOGLE_CLIENT_ID}';
+    const CLIENT_SECRET = '${env.GOOGLE_CLIENT_SECRET}';
     const REDIRECT_URI = window.location.origin + '/';
 
     async function exchange(code) {


### PR DESCRIPTION
## Summary
- Inject Cloudflare environment variables for Google OAuth client ID and secret into the UI
- Pass worker environment to UI renderer

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad343bcb508325a5aeaec7314d9eba