### PR TITLE
Fix site verification type mapping

### DIFF
--- a/src/google.ts
+++ b/src/google.ts
@@ -55,10 +55,11 @@ export async function refresh(env: Env, refresh_token: string) {
 
 export async function getVerificationToken(accessToken: string, site: string, type: 'DOMAIN' | 'URL_PREFIX'): Promise<ApiResponse> {
   const method = type === 'DOMAIN' ? 'DNS_TXT' : 'META';
+  const siteType = type === 'DOMAIN' ? 'INET_DOMAIN' : 'SITE';
   const res = await fetch(`${SITEVERIFICATION}/token?verificationMethod=${method}`, {
     method: 'POST',
     headers: { 'Authorization': `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ site: { identifier: site, type } })
+    body: JSON.stringify({ site: { identifier: site, type: siteType } })
   });
   if (!res.ok) return { success: false, summary: 'Failed to obtain token', details: await res.json() };
   const data = await res.json();
@@ -67,10 +68,11 @@ export async function getVerificationToken(accessToken: string, site: string, ty
 
 export async function verifySite(accessToken: string, site: string, type: 'DOMAIN' | 'URL_PREFIX'): Promise<ApiResponse> {
   const method = type === 'DOMAIN' ? 'DNS_TXT' : 'META';
+  const siteType = type === 'DOMAIN' ? 'INET_DOMAIN' : 'SITE';
   const res = await fetch(`${SITEVERIFICATION}/webResource?verificationMethod=${method}`, {
     method: 'POST',
     headers: { 'Authorization': `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ site: { identifier: site, type } })
+    body: JSON.stringify({ site: { identifier: site, type: siteType } })
   });
   if (!res.ok) return { success: false, summary: 'Verification failed', details: await res.json() };
   return { success: true, summary: 'Site verified', details: await res.json() };

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -106,9 +106,10 @@ input { margin-right: 0.5rem; }
         const type = typeSelect.value;
         if (!site) return alert('Enter site');
         const method = type === 'DOMAIN' ? 'DNS_TXT' : 'META';
+        const siteType = type === 'DOMAIN' ? 'INET_DOMAIN' : 'SITE';
         const res = await api('https://www.googleapis.com/siteVerification/v1/token?verificationMethod=' + method, {
           method: 'POST',
-          body: JSON.stringify({ site: { identifier: site, type } })
+          body: JSON.stringify({ site: { identifier: site, type: siteType } })
         });
         if (res.token) {
           tokenOut.textContent = type === 'DOMAIN'
@@ -127,9 +128,10 @@ input { margin-right: 0.5rem; }
         const type = typeSelect.value;
         if (!site) return alert('Enter site');
         const method = type === 'DOMAIN' ? 'DNS_TXT' : 'META';
+        const siteType = type === 'DOMAIN' ? 'INET_DOMAIN' : 'SITE';
         const res = await api('https://www.googleapis.com/siteVerification/v1/webResource?verificationMethod=' + method, {
           method: 'POST',
-          body: JSON.stringify({ site: { identifier: site, type } })
+          body: JSON.stringify({ site: { identifier: site, type: siteType } })
         });
         alert(res.error ? 'Verification failed' : 'Site verified');
       };


### PR DESCRIPTION
## Summary
- map Search Console property types to Site Verification API's `INET_DOMAIN` and `SITE`
- mirror this mapping in the UI to avoid `Invalid value at 'site.type'`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad3e0fed5083258ddc3d608feb7848