### PR TITLE
Add bulk sitemap indexing with progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is deliberately minimal and friendly. Each step returns human‑readable summ
 
 ## Using
 
-Visit the worker URL. The page invites you to connect a Google account. After OAuth completes, simple controls appear to fetch a DNS verification token, confirm verification, request URL indexing and submit a sitemap. The same operations are also available via JSON endpoints:
+Visit the worker URL. The page invites you to connect a Google account. After OAuth completes, simple controls appear to fetch a DNS verification token, confirm verification, request URL indexing, submit a sitemap, and bulk index every URL in a sitemap with progress feedback. The same operations are also available via JSON endpoints:
 
 - `POST /api/verify` to receive a verification token.
 - `POST /api/confirm` once the token is placed.


### PR DESCRIPTION
## Summary
- allow indexing every URL from a submitted sitemap
- show progress and per-URL results during bulk indexing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae55fc2bd08325bd17577992b965c3