### PR TITLE
Handle OAuth code exchange on server to hide client secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ It is deliberately minimal and friendly. Each step returns human‑readable summ
 3. Bind a KV namespace named `TOKENS` for storing user tokens.
 4. Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in your worker environment.
 5. Run `wrangler publish`.
+6. The worker performs OAuth token exchanges server-side so your client secret never appears in the browser.
 
 ## Using
 
 Visit the worker URL. The page invites you to connect a Google account. After OAuth completes, simple controls appear to fetch a DNS verification token, confirm verification, request URL indexing, submit a sitemap, and bulk index every URL in a sitemap with progress feedback. The same operations are also available via JSON endpoints:
 
+- `POST /api/token` to exchange an authorization code for tokens.
 - `POST /api/verify` to receive a verification token.
 - `POST /api/confirm` once the token is placed.
 - `POST /api/property` to add the site to Search Console.

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,10 +1,22 @@
 import { renderUI } from './ui';
+import { exchangeCode } from './google';
 import { Env } from './types';
 
 export async function handleRequest(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
   const url = new URL(request.url);
   if (url.pathname === '/' && request.method === 'GET') {
     return renderUI(env);
+  }
+  if (url.pathname === '/api/token' && request.method === 'POST') {
+    const { code, redirect_uri } = await request.json() as { code: string; redirect_uri: string };
+    try {
+      const data = await exchangeCode(env, code, redirect_uri);
+      return new Response(JSON.stringify(data), {
+        headers: { 'Content-Type': 'application/json' }
+      });
+    } catch (err) {
+      return new Response('token exchange failed', { status: 500 });
+    }
   }
   return new Response('Not found', { status: 404 });
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -20,7 +20,6 @@ input { margin-right: 0.5rem; }
   <script type="module">
     (async () => {
     const CLIENT_ID = '${env.GOOGLE_CLIENT_ID}';
-    const CLIENT_SECRET = '${env.GOOGLE_CLIENT_SECRET}';
     const REDIRECT_URI = window.location.origin + '/';
 
     const logEl = document.createElement('pre');
@@ -34,14 +33,11 @@ input { margin-right: 0.5rem; }
 
     async function exchange(code) {
       log('Exchanging authorization code');
-      const body = new URLSearchParams({
-        code,
-        client_id: CLIENT_ID,
-        client_secret: CLIENT_SECRET,
-        redirect_uri: REDIRECT_URI,
-        grant_type: 'authorization_code'
+      const res = await fetch('/api/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code, redirect_uri: REDIRECT_URI })
       });
-      const res = await fetch('https://oauth2.googleapis.com/token', { method: 'POST', body });
       if (!res.ok) throw new Error('token exchange failed');
       const data = await res.json();
       log('Token response: ' + JSON.stringify(data));


### PR DESCRIPTION
## Summary
- move OAuth code exchange to `/api/token`
- remove client secret from client-side script
- document new token exchange endpoint

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae82aef2e483259a19e85b80111499